### PR TITLE
db: UPDATE and SELECT at once

### DIFF
--- a/db.ts
+++ b/db.ts
@@ -22,11 +22,8 @@ interface Counts {
 }
 
 export async function getCount(): Promise<number> {
-  // update
-  await conn.execute(`UPDATE counts SET count = count + 1 WHERE id = 1`);
-
-  // get new value. Can/should this be done in one query?
-  const response = await conn.execute(`SELECT * FROM counts WHERE id = 1`);
+  // update and read the new value
+  const response = await conn.execute(`WITH result AS (UPDATE counts SET count = count + 1 WHERE id = 1) SELECT count FROM counts`);
 
   const [visits] = response.rows as Counts[];
   return visits.count;


### PR DESCRIPTION
Avoid two separate database queries by doing the UPDATE with a CTE so we
can SELECT the new results in one go.

This query could have made use of RETURNING, unfortunately that's not
supported in MySQL.
